### PR TITLE
Improving color contrast issues

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -51,7 +51,7 @@ body {
   font-family: 'Helvetica Neue', Helvetica, Arial, serif;
   font-size: 1em;
   line-height: 1.5;
-  color: #6d6d6d;
+  color: #000;
   text-shadow: 0 1px 0 rgba(255, 255, 255, 0.8);
   background: #e7e7e7 url(../images/body-bg.png) 0 0 repeat;
 }
@@ -80,7 +80,7 @@ header h2 {
   font-size: 24px;
   font-weight: normal;
   line-height: 1.3;
-  color: #aaa;
+  color: #404040;
   letter-spacing: -1px;
 }
 
@@ -311,12 +311,12 @@ footer {
   padding-bottom: 30px;
   margin-top: 40px;
   font-size: 13px;
-  color: #aaa;
+  color: #404040;
   background: transparent url('../images/hr.png') 0 0 no-repeat;
 }
 
 footer a {
-  color: #666;
+  color: #2B2B2B;
 }
 footer a:hover {
   color: #444;


### PR DESCRIPTION
The CSS Naked Day site text currently has very low contrast.

The body text has a contrast ratio of 4.18:1. The footer and header h2 have a contrast ratio of 1.87:1.

This PR boosts the contrast ratios to roughly 16.98:1 and 8.38:1 respectively, making the site much more readable and accessible.