### PR TITLE
Add NOVALISTIC.com to 2020.html

### DIFF
--- a/2020.html
+++ b/2020.html
@@ -58,6 +58,7 @@
             <li><a href="https://meyerweb.com/">Eric Meyer</a></li>
             <li><a href="https://davidroessli.com/">David Roessli</a></li>
             <li><a href="https://lukeb.co.uk/">Luke Bonaccorsi</a></li>
+            <li><a href="https://novalistic.com">Daniel Tan</a></li>
           </ol>
         </section>
 


### PR DESCRIPTION
Nice to see that my blog formerly known as BoltPress remains immortalized in the 2008 and 2009 lists 👍