### PR TITLE
Homepage: Feature date, remove google groups link

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
         <section id="main_content">
           <h3>Welcome to the CSS Naked Day website!</h3>
 
-          <p>Join us for the yearly festivities of going nude on the web!</p>
+          <p>Join us for the yearly festivities on April 9th of going nude on the web!</p>
 
           <h3><a id="where-is-design" class="anchor" href="#where-is-design">
             Where did the design go?
@@ -50,8 +50,6 @@
           <p>On April 9th, simply remove all CSS from your website, stripping it entirely of its design.</p>
 
           <p>You can link to this page to let your visitors know about the nudity of your website! This option is for those who feel a need to give their visitors a reference as to what's going on. This is not about getting traffic or making money. There are no ads on this site, nor will there ever be. This is about you, the people; getting naked.</p>
-
-          <p>There is also a <a href="https://groups.google.com/forum/#!forum/css-naked-day">Google group dedicated to CSS Naked day</a>.</p>
 
           <h3><a id="developers" class="anchor" href="#developers">Don't think, just strip</a></h3>
 


### PR DESCRIPTION
Two unasked for suggestions: 

1. Add the date of April 9th up higher on the page (I always have to read for "when is it again?")
2. Remove the callout for the google group as the last post was more than 4 years ago in March 2017

Hope it's helpful.