### PR TITLE
Add Go Free Range to 2022 & 2023 lists

### DIFF
--- a/2022.html
+++ b/2022.html
@@ -64,6 +64,7 @@
             <li><a href="https://www.tempertemper.net/">Martin Underhill</a></li>
             <li><a href="https://wolstenhol.me/">Phil Wolstenholme</a></li>
             <li><a href="https://shkspr.mobi/blog/">Terence Eden</a></li>
+            <li><a href="https://gofreerange.com/">Go Free Range</a></li>
           </ol>
         </section>
 

--- a/2023.html
+++ b/2023.html
@@ -59,6 +59,7 @@
             <li><a href="https://www.farai.xyz/">Farai</li>
             <li><a href="https://fiehe.info/">Fiehe.info</a></li>
             <li><a href="https://www.germanfrelo.dev/">Germán Freixinós López</a></li>
+            <li><a href="https://gofreerange.com/">Go Free Range</a></li>
             <li><a href="https://knowler.dev/">Nathan Knowler</a></li>
             <li>Jens Oliver Meiert: <a href="https://frontenddogma.com/">Frontend Dogma</a></li>
             <li><a href="https://davidroessli.com/">David Roessli</a></li>


### PR DESCRIPTION
We've been doing this [every year][1] [since 2021][2], so I thought I'd fill in the blanks.

[1]: https://github.com/freerange/site/commit/2c73e869542026411fc8e69b51d8acb302a93922
[2]: https://github.com/css-naked-day/css-naked-day.github.io/pull/39