### PR TITLE
Update viewport meta tags

### DIFF
--- a/2006.html
+++ b/2006.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Chivo:900">
     <link rel="stylesheet" href="setup/default.css">
-    <meta name="viewport" content="initial-scale=1,minimum-scale=1,width=device-width">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2006">

--- a/2007.html
+++ b/2007.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Chivo:900">
     <link rel="stylesheet" href="setup/default.css">
-    <meta name="viewport" content="initial-scale=1,minimum-scale=1,width=device-width">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2007">

--- a/2008.html
+++ b/2008.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Chivo:900">
     <link rel="stylesheet" href="setup/default.css">
-    <meta name="viewport" content="initial-scale=1,minimum-scale=1,width=device-width">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2008">

--- a/2009.html
+++ b/2009.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Chivo:900">
     <link rel="stylesheet" href="setup/default.css">
-    <meta name="viewport" content="initial-scale=1,minimum-scale=1,width=device-width">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2009">

--- a/2015.html
+++ b/2015.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Chivo:900">
     <link rel="stylesheet" href="setup/default.css">
-    <meta name="viewport" content="initial-scale=1,minimum-scale=1,width=device-width">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2015">

--- a/2020.html
+++ b/2020.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Chivo:900">
     <link rel="stylesheet" href="setup/default.css">
-    <meta name="viewport" content="initial-scale=1,minimum-scale=1,width=device-width">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2020">

--- a/2021.html
+++ b/2021.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Chivo:900">
     <link rel="stylesheet" href="setup/default.css">
-    <meta name="viewport" content="initial-scale=1,minimum-scale=1,width=device-width">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2021">

--- a/2022.html
+++ b/2022.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Chivo:900">
     <link rel="stylesheet" href="setup/default.css">
-    <meta name="viewport" content="initial-scale=1,minimum-scale=1,width=device-width">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2022">

--- a/2023.html
+++ b/2023.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Chivo:900">
     <link rel="stylesheet" href="setup/default.css">
-    <meta name="viewport" content="initial-scale=1,minimum-scale=1,width=device-width">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2023">

--- a/2024.html
+++ b/2024.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Chivo:900">
     <link rel="stylesheet" href="setup/default.css">
-    <meta name="viewport" content="initial-scale=1,minimum-scale=1,width=device-width">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2024">

--- a/2025.html
+++ b/2025.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Chivo:900">
     <link rel="stylesheet" href="setup/default.css">
-    <meta name="viewport" content="initial-scale=1,minimum-scale=1,width=device-width">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2025">

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Chivo:900">
     <link rel="stylesheet" href="setup/default.css">
-    <meta name="viewport" content="initial-scale=1,minimum-scale=1,width=device-width">
+    <meta name="viewport" content="initial-scale=1,width=device-width">
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day">


### PR DESCRIPTION
Remove the "minimum-scale" attribute from viewport meta tags. This change enhances the initial layout for modern devices while maintaining the intended scale settings.

[Left AI-generated commit message as is—background is wider project refactoring, where this came up as something not needed anymore.]