### PR TITLE
feat: add LinebyLine to participants list

### DIFF
--- a/2023.html
+++ b/2023.html
@@ -61,6 +61,7 @@
             <li><a href="https://fiehe.info/">Fiehe.info</a></li>
             <li><a href="https://www.germanfrelo.dev/">Germán Freixinós López</a></li>
             <li><a href="https://gofreerange.com/">Go Free Range</a></li>
+            <li><a href="https://linebyline.de/">LinebyLine</a></li>
             <li><a href="https://knowler.dev/">Nathan Knowler</a></li>
             <li>Jens Oliver Meiert: <a href="https://frontenddogma.com/">Frontend Dogma</a></li>
             <li><a href="https://davidroessli.com/">David Roessli</a></li>


### PR DESCRIPTION
Helping @Peter23221. PR supersedes #171, which cannot be merged.

@Peter23221, can you provide me with some more details about your participation? When having a look <a href="https://web.archive.org/web/https://www.linebyline.de/">at archive.org</a>, I cannot find a version of the site that was either functional or fit to participate in CSS N/D. How did the site look like in 2023?

(@arkhi, if you have more thoughts on this, let’s please chat off-thread. Would love some alignment on how we like to handle cases like this one.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated CSS Naked Day 2023 participant list
	- Added LinebyLine website to the recognized participants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->