### PR TITLE
feat: enable links for the 2025 edition

### DIFF
--- a/2006.html
+++ b/2006.html
@@ -45,7 +45,7 @@
             · <a href="2022.html">2022</a>
             · <a href="2023.html">2023</a>
             · <a href="2024.html">2024</a>
-            <!-- · <a href="2025.html">2025</a> -->
+            · <a href="2025.html">2025</a>
           </p>
 
           <h3>Kudos to these websites who got naked in 2006!</h3>

--- a/2007.html
+++ b/2007.html
@@ -45,7 +45,7 @@
             · <a href="2022.html">2022</a>
             · <a href="2023.html">2023</a>
             · <a href="2024.html">2024</a>
-            <!-- · <a href="2025.html">2025</a> -->
+            · <a href="2025.html">2025</a>
           </p>
 
           <h3>Kudos to these websites who got naked in 2007!</h3>

--- a/2008.html
+++ b/2008.html
@@ -45,7 +45,7 @@
             · <a href="2022.html">2022</a>
             · <a href="2023.html">2023</a>
             · <a href="2024.html">2024</a>
-            <!-- · <a href="2025.html">2025</a> -->
+            · <a href="2025.html">2025</a>
           </p>
 
           <h3>Kudos to these websites who got naked in 2008!</h3>

--- a/2009.html
+++ b/2009.html
@@ -45,7 +45,7 @@
             · <a href="2022.html">2022</a>
             · <a href="2023.html">2023</a>
             · <a href="2024.html">2024</a>
-            <!-- · <a href="2025.html">2025</a> -->
+            · <a href="2025.html">2025</a>
           </p>
 
           <h3>Kudos to these websites who got naked in 2009!</h3>

--- a/2015.html
+++ b/2015.html
@@ -45,7 +45,7 @@
             · <a href="2022.html">2022</a>
             · <a href="2023.html">2023</a>
             · <a href="2024.html">2024</a>
-            <!-- · <a href="2025.html">2025</a> -->
+            · <a href="2025.html">2025</a>
           </p>
 
           <h3>Kudos to these websites who got naked in 2015!</h3>

--- a/2020.html
+++ b/2020.html
@@ -45,7 +45,7 @@
             · <a href="2022.html">2022</a>
             · <a href="2023.html">2023</a>
             · <a href="2024.html">2024</a>
-            <!-- · <a href="2025.html">2025</a> -->
+            · <a href="2025.html">2025</a>
           </p>
 
           <h3>Kudos to these websites who got naked in 2020!</h3>

--- a/2021.html
+++ b/2021.html
@@ -45,7 +45,7 @@
             · <a href="2022.html">2022</a>
             · <a href="2023.html">2023</a>
             · <a href="2024.html">2024</a>
-            <!-- · <a href="2025.html">2025</a> -->
+            · <a href="2025.html">2025</a>
           </p>
 
           <h3>Kudos to these websites who got naked in 2021!</h3>

--- a/2022.html
+++ b/2022.html
@@ -45,7 +45,7 @@
             · <a href="2022.html">2022</a>
             · <a href="2023.html">2023</a>
             · <a href="2024.html">2024</a>
-            <!-- · <a href="2025.html">2025</a> -->
+            · <a href="2025.html">2025</a>
           </p>
 
           <h3>Kudos to these websites who got naked in 2022!</h3>

--- a/2023.html
+++ b/2023.html
@@ -45,7 +45,7 @@
             · <a href="2022.html">2022</a>
             · <a href="2023.html">2023</a>
             · <a href="2024.html">2024</a>
-            <!-- · <a href="2025.html">2025</a> -->
+            · <a href="2025.html">2025</a>
           </p>
 
           <h3>Kudos to these websites who got naked in 2023!</h3>

--- a/2024.html
+++ b/2024.html
@@ -45,7 +45,7 @@
             · <a href="2022.html">2022</a>
             · <a href="2023.html">2023</a>
             · <a href="2024.html">2024</a>
-            <!-- · <a href="2025.html">2025</a> -->
+            · <a href="2025.html">2025</a>
           </p>
 
           <h3>Kudos to these websites who got naked in 2024!</h3>

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
           <h3><a id="editions" href="#editions">CSS Naked Day editions</a></h3>
 
           <ul>
-            <!-- <li><a href="2025.html">2025</a></li> -->
+            <li><a href="2025.html">2025</a></li>
             <li><a href="2024.html">2024</a></li>
             <li><a href="2023.html">2023</a></li>
             <li><a href="2022.html">2022</a></li>


### PR DESCRIPTION
Uncommented and activated links to the CSS Naked Day 2025 edition across relevant HTML files. This ensures navigation to the 2025 edition is now functional for users.

(This commit message was AI-generated.)