### PR TITLE
fix: update outdated URLs to css-naked-day.org

### DIFF
--- a/2006.html
+++ b/2006.html
@@ -9,7 +9,7 @@
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2006">
-    <meta property="og:image" content="https://css-naked-day.github.io/media/logo.png">
+    <meta property="og:image" content="https://css-naked-day.org/media/logo.png">
   </head>
 
   <body>

--- a/2007.html
+++ b/2007.html
@@ -9,7 +9,7 @@
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2007">
-    <meta property="og:image" content="https://css-naked-day.github.io/media/logo.png">
+    <meta property="og:image" content="https://css-naked-day.org/media/logo.png">
   </head>
 
   <body>

--- a/2008.html
+++ b/2008.html
@@ -9,7 +9,7 @@
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2008">
-    <meta property="og:image" content="https://css-naked-day.github.io/media/logo.png">
+    <meta property="og:image" content="https://css-naked-day.org/media/logo.png">
   </head>
 
   <body>

--- a/2009.html
+++ b/2009.html
@@ -9,7 +9,7 @@
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2009">
-    <meta property="og:image" content="https://css-naked-day.github.io/media/logo.png">
+    <meta property="og:image" content="https://css-naked-day.org/media/logo.png">
   </head>
 
   <body>

--- a/2015.html
+++ b/2015.html
@@ -9,7 +9,7 @@
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2015">
-    <meta property="og:image" content="https://css-naked-day.github.io/media/logo.png">
+    <meta property="og:image" content="https://css-naked-day.org/media/logo.png">
   </head>
 
   <body>

--- a/2020.html
+++ b/2020.html
@@ -9,7 +9,7 @@
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2020">
-    <meta property="og:image" content="https://css-naked-day.github.io/media/logo.png">
+    <meta property="og:image" content="https://css-naked-day.org/media/logo.png">
   </head>
 
   <body>

--- a/2021.html
+++ b/2021.html
@@ -9,7 +9,7 @@
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2021">
-    <meta property="og:image" content="https://css-naked-day.github.io/media/logo.png">
+    <meta property="og:image" content="https://css-naked-day.org/media/logo.png">
   </head>
 
   <body>

--- a/2022.html
+++ b/2022.html
@@ -9,7 +9,7 @@
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2022">
-    <meta property="og:image" content="https://css-naked-day.github.io/media/logo.png">
+    <meta property="og:image" content="https://css-naked-day.org/media/logo.png">
   </head>
 
   <body>

--- a/2023.html
+++ b/2023.html
@@ -9,7 +9,7 @@
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2023">
-    <meta property="og:image" content="https://css-naked-day.github.io/media/logo.png">
+    <meta property="og:image" content="https://css-naked-day.org/media/logo.png">
   </head>
 
   <body>

--- a/2024.html
+++ b/2024.html
@@ -9,7 +9,7 @@
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2024">
-    <meta property="og:image" content="https://css-naked-day.github.io/media/logo.png">
+    <meta property="og:image" content="https://css-naked-day.org/media/logo.png">
   </head>
 
   <body>

--- a/2025.html
+++ b/2025.html
@@ -9,7 +9,7 @@
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day 2025">
-    <meta property="og:image" content="https://css-naked-day.github.io/media/logo.png">
+    <meta property="og:image" content="https://css-naked-day.org/media/logo.png">
   </head>
 
   <body>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CSS Naked Day
 
-“Show off your semantic `<body>`”: [_April 9 is CSS Naked Day!_](https://css-naked-day.github.io/)
+“Show off your semantic `<body>`”: [_April 9 is CSS Naked Day!_](https://css-naked-day.org/)
 
 If you’re participating, [update the respective file](https://github.com/css-naked-day/css-naked-day.github.io) to add your website(s).
 

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <meta name="description" property="og:description" content="April 9 is CSS Naked Day!">
     <meta name="twitter:card" content="summary">
     <meta property="og:title" content="CSS Naked Day">
-    <meta property="og:image" content="https://css-naked-day.github.io/media/logo.png">
+    <meta property="og:image" content="https://css-naked-day.org/media/logo.png">
   </head>
 
   <body>


### PR DESCRIPTION
Replaced all instances of css-naked-day.github.io with css-naked-day.org. This ensures consistency across resources and updates to the correct domain.

(This commit message was AI-generated.)