### PR TITLE
Only deploy to prod when a Pull Request is merged to master.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,5 +12,5 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.ya?ml]
+[*.{yml,yaml}]
 indent_style = space

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -3,8 +3,6 @@ name: Deploy Eleventy on prod via rsync
 on:
   push:
     branches: [master]
-  pull_request:
-    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,22 @@
+name: Test building Eleventy when a Pull Request is created or updated.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Check-out the repository under $GITHUB_WORKSPACE.
+      - uses: actions/checkout@master
+
+      - name: Install dependencies.
+        run: npm ci
+
+      - name: Lint with fix.
+        run: npx eslint --fix
+
+      # Build the website with Eleventy.
+      - name: Build Eleventy.
+        run: npm run build


### PR DESCRIPTION
- Run tests up to building Eleventy whenever some [pull_request](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request) events are triggered (`opened`, `edited`, `reopened` or `synchronize`). A [GitHub page describes these events](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=synchronize#pull_request).
- Deploy to prod when the PR is merged to _master_.
- Fix editor config for yaml files. It uses [glob expressions](https://spec.editorconfig.org/#glob-expressions), not regeular expressions.