### PR TITLE
fix: Update deploy script after renaming main branch

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -2,7 +2,7 @@ name: Deploy Eleventy on prod via rsync
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
The deploy script is conditioned to a branch that does not exist any more since renaming.