### PR TITLE
fix: Wrong name for global

### DIFF
--- a/_src/current-year-urls.njk
+++ b/_src/current-year-urls.njk
@@ -2,6 +2,6 @@
 permalink: /current-year-urls.txt
 ---
 
-{%- for url in globals.currentYear | getWebsitesForYear %}
+{%- for url in globals.yearCurrent | getWebsitesForYear %}
 	{{- url }}
 {% endfor -%}


### PR DESCRIPTION
I don’t know how this came to be, but the name for the current year’s variable is wrong.

This PR uses the [proper name](https://github.com/css-naked-day/css-naked-day.org/blob/7a8dfd6b4e41621dd1ba7aedd70ec0ab775ee69e/_src/_data/globals.js#L3).