### PR TITLE
Show CTA/link only for current/latest year

### DIFF
--- a/_src/year.njk
+++ b/_src/year.njk
@@ -51,7 +51,9 @@ permalink: /{{ year | slugify }}.html
 	{% endfor %}
 </ol>
 
-<p>
-	Feel free to
-	<a href='https://source.css-naked-day.org/css-naked-day.org/new/main/?filename=_data/participants/my-name.toml&value=display%20%3D%20%22MY%20NAME%22%0A%0A%23%20Websites%0A%23%20------------------------------------------------------------------------------%0A%0A%5B%5Bwebsites%5D%5D%0Aurl%20%20%20%3D%20%22URL_OF_MY_WEBSITE%22%0Ayears%20%3D%20%5B%0A%20%20%0A%5D'>add yours</a>!
-</p>
+{% if year === globals.yearCurrent %}
+	<p>
+		Feel free to
+		<a href='https://source.css-naked-day.org/css-naked-day.org/new/main/?filename=_data/participants/my-name.toml&value=display%20%3D%20%22MY%20NAME%22%0A%0A%23%20Websites%0A%23%20------------------------------------------------------------------------------%0A%0A%5B%5Bwebsites%5D%5D%0Aurl%20%20%20%3D%20%22URL_OF_MY_WEBSITE%22%0Ayears%20%3D%20%5B%0A%20%20%0A%5D'>add yours</a>!
+	</p>
+{% endif %}


### PR DESCRIPTION
Proposing that we show the “Feel free to add yours!” blurb only on the respective last year—this is where it’s most useful.

Anyone who participated many years back can still propose an update.