### PR TITLE
Revert some previous changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,8 @@ npm run build
 ```bash
 npm run dev
 ```
+
+[css-naked-day.org]: https://css-naked-day.org/
+[Naked Days Corp]: https://css-naked-day.org/
+[CSS Naked Day]: https://css-naked-day.org/
+[JS Naked Day]: https://js-naked-day.org/


### PR DESCRIPTION
A [previous PR](https://github.com/css-naked-day/css-naked-day.org/pull/314) broke all links involving references to _css-naked-day.org_, _Naked Days Corp_, _CSS Naked Day_ or _JS Naked Day_.

```md
The following will show as “[css-naked-day.org][]”:
```
displays as it is written instead of _The following will show as “[css-naked-day.org](https://css-naked-day.org/)”:_.
